### PR TITLE
clay_config: input type search

### DIFF
--- a/src/pkjs/data/clay_config.js
+++ b/src/pkjs/data/clay_config.js
@@ -26,7 +26,7 @@ module.exports =
           "autocapitalize": "off",
           "autocorrect": "off",
           "autocomplete": "off",
-          "type": "url",
+          "type": "search",
           "spellcheck": false,
           "required": true
         }


### PR DESCRIPTION
Allow searching for results with spaces